### PR TITLE
scope plugins to support adjusting app base path

### DIFF
--- a/packages/fastify-podlet-server/commands/dev.js
+++ b/packages/fastify-podlet-server/commands/dev.js
@@ -90,6 +90,12 @@ const started = await start({
   logger: LOGGER,
   // @ts-ignore
   app: (app, opts, done) => {
+    if (config.get('app.base') !== "/") {
+      app.get("/", (request, reply) => {
+        reply.redirect(config.get('app.base'));
+      })
+    }
+
     app.register(fastifyPodletPlugin, { config });
 
     app.addHook('onError', (request, reply, error, done) => {
@@ -99,7 +105,7 @@ const started = await start({
 
     // register user provided plugin using sandbox to enable reloading
     if (existsSync(SERVER_FILEPATH)) {
-      app.register(sandbox, { path: SERVER_FILEPATH, options: { config, podlet: app.podlet } });
+      app.register(sandbox, { path: SERVER_FILEPATH, options: { prefix: config.get('app.base'), config, podlet: app.podlet } });
     }
 
     done();

--- a/packages/fastify-podlet-server/commands/start.js
+++ b/packages/fastify-podlet-server/commands/start.js
@@ -8,7 +8,7 @@ import config from "../lib/config.js";
 
 const app = fastify({ logger: true, ignoreTrailingSlash: true });
 
-app.register(fastifyPodletPlugin, { config });
+app.register(fastifyPodletPlugin, { prefix: config.get("app.base"), config });
 
 /** @type {any} */
 let fastifyApp = app;
@@ -19,7 +19,11 @@ const podlet = fastifyApp.podlet;
 const serverFilePath = join(process.cwd(), "server.js");
 if (existsSync(serverFilePath)) {
   const server = (await import(serverFilePath)).default;
-  app.register(server, { config, podlet });
+  app.register(server, { prefix: config.get("app.base"), config, podlet });
 }
 
-app.listen({ port: config.get("app.port") });
+try {
+await app.listen({ port: config.get("app.port") });
+} catch(err) {
+  console.log(err)
+}

--- a/packages/fastify-podlet-server/lib/config-schema.js
+++ b/packages/fastify-podlet-server/lib/config-schema.js
@@ -20,6 +20,13 @@ export const schema = {
       env: "DOMAIN",
       arg: "domain",
     },
+    base: {
+      doc: "The base pathname to mount the app routes on. Defaults to the app name",
+      format: String,
+      default: "",
+      env: "APP_BASE",
+      arg: "app-base",
+    },
     port: {
       doc: "The port to expose the http service on",
       format: "port",
@@ -125,9 +132,9 @@ export const schema = {
   },
   assets: {
     base: {
-      doc: "Base path or URL for assets. Eg. /static or https://assets.cdn.com/static. Locally this is files in the dist folder. DO NOT include trailing slash.",
+      doc: "Base path or URL for assets. Eg. /static or https://assets.cdn.com/static. DO NOT include trailing slash.",
       format: String,
-      default: "/static",
+      default: "",
     },
     development: {
       doc: "Asset development mode. When enabled, content and fallback will be wrapped in development scripts. Should be set to false when in production.",

--- a/packages/fastify-podlet-server/lib/config.js
+++ b/packages/fastify-podlet-server/lib/config.js
@@ -11,8 +11,8 @@ convict.addFormats(formats);
 // will be merged into the base config and can then be overridden as needed
 // for specific environments, domains or globally.
 let userSchema = {};
-if (existsSync(join(process.cwd(), "config/schema.js"))) {
-  userSchema = (await import(join(process.cwd(), "config/schema.js"))).default;
+if (existsSync(`${join(process.cwd(), "config", "schema")}.js`)) {
+  userSchema = (await import(`${join(process.cwd(), "config", "schema")}.js`)).default;
 }
 
 const config = convict({ ...schema, ...userSchema });
@@ -36,7 +36,11 @@ if (env === "local") {
 
 // name defaults to the name field in package.json
 const { name } = JSON.parse(await readFile(join(process.cwd(), "package.json"), { encoding: "utf8" }));
-config.load({ app: { name } });
+// makes it possible to change the path that the app is mounted at by changing config.
+// {
+//   "app": { "base": "/" }
+// }
+config.load({ app: { name, base: `/${name}` } });
 
 // if a fallback is defined, set the fallback path
 // this is so that the Podlet object fallback setting does not get set if no fallback is defined.
@@ -46,14 +50,14 @@ if (existsSync(join(process.cwd(), "fallback.js"))) {
 
 // load comon config overrides if provided
 // common.json is supported so that users can override core config without needing to override for multiple environments or domains
-if (existsSync(join(process.cwd(), "config/common.json"))) {
-  config.loadFile(join(process.cwd(), "config/common.json"));
+if (existsSync(join(process.cwd(), `${join("config", "common")}.json`))) {
+  config.loadFile(join(process.cwd(), `${join("config", "common")}.json`));
 }
 
 // load specific overrides if provided
 // fine grained config overrides. Domain and env overrides etc.
-if (existsSync(join(process.cwd(), `config/domains/${domain}/config.${env}.json`))) {
-  config.loadFile(join(process.cwd(), `config/domains/${domain}/config.${env}.json`));
+if (existsSync(join(process.cwd(), `${join("config", "domains", domain, "config")}.${env}.json`))) {
+  config.loadFile(join(process.cwd(), `${join("config", "domains", domain, "config")}.${env}.json`));
 }
 
 // once all is setup, validate.


### PR DESCRIPTION
This PR makes it possible to set an `app.base` config value and have the whole app mounted in the server correctly based on this value. If the value is not set, the app uses the `app.name` as the pathname instead.

## Behaviour is as follows:
* no app.base set, app base pathname set to /<app.name>
* app.base set, app base pathname set to /<app.base> n.b. app.base can be set to / to have the app mounted at the root.
* all routes are mounted under the pathname, this goes for manifest, content, fallback and any additional api routes and locally served static assets

## Assets
There is an assets.base value which has some interaction with app.base. assets.base behaviour is as follows
* defaults to /static locally which is where the dist folder is served. 
* If assets.base is set to an absolute url then local assets will not be served and assets will be loaded from this absolute url. 
* If assets.base is not an absolute value, it will be concatenated with the app pathname (as above, either from app.base or app.name)

### Examples:

```json5
// config/common.json
{
  "app": {
    "base": "/foo"
  },
  "assets": {
    "base": "/bar"
  }
}

// app served at http://localhost:8080/foo
// app assets served at http://localhost:8080/foo/bar
```

```json5
// config/common.json
{
  "app": {
    "base": "/foo"
  }
}

// app served at http://localhost:8080/foo
// app assets served at http://localhost:8080/foo/static
```

```json5
// config/common.json
{
  "app": {
    "base": "/foo"
  },
  "assets": {
    "base": "https://assets.foo.com/static"
  }
}

// app served at http://localhost:8080/foo
// app assets served at https://assets.foo.com/static
```

```json5
// package.json
{
  "name": "foo"
}

// config/common.json
{}

// app served at http://localhost:8080/foo
// app assets served at http://localhost:8080/foo/static
```

```json5
// package.json
{
  "name": "foo"
}

// config/common.json
{
  "assets": {
    "base": "/bar"
  }
}

// app served at http://localhost:8080/foo
// app assets served at http://localhost:8080/foo/bar
```