### PR TITLE
refactor plugin structure to class with .plugin method

### DIFF
--- a/packages/fastify-podlet-server/lib/config-schema.js
+++ b/packages/fastify-podlet-server/lib/config-schema.js
@@ -67,11 +67,6 @@ export const schema = {
       format: Number,
       default: 0,
     },
-    processExceptionHandlers: {
-      doc: "Use built in process exception handlers",
-      format: Boolean,
-      default: true,
-    },
     compression: {
       doc: "Enables/disables compression on routes",
       format: Boolean,
@@ -123,11 +118,6 @@ export const schema = {
         format: Boolean,
         default: true,
       },
-    },
-    enabled: {
-      doc: "Enable/disable metrics collection",
-      format: Boolean,
-      default: true,
     },
   },
   assets: {


### PR DESCRIPTION
This PR refactors the plugin function into a class which follows more of a similar style to other Podium modules.

The ulterior motive for this is that Fastify does some funky things with plugin scoping so in order to have cake and eat it too here I needed to define 2 layers of plugins (this is right out of the Fastify docs btw). 

The outer layer includes the "fastify-plugin" module which removes scoping and allows decorators and such to be available in other plugins and in the parent scope. I have to define decorators at this level otherwise they will not exist outside this module.

The inner layer does not include the "fastify-plugin" module which allows scoping and in particular route prefixing to work as expected. This means that we can use config to set the route prefix to / or /<app name> or what have you correctly.

By splitting out into a class I was able to better control the 2 plugin layers, use route prefixing on the inner layer and decorators on the outer layer.