### PR TITLE
deep merge user config with system config

### DIFF
--- a/packages/fastify-podlet-server/lib/config.js
+++ b/packages/fastify-podlet-server/lib/config.js
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import convict from "convict";
 import { schema, formats } from "./config-schema.js";
+import merge from "lodash.merge";
 
 convict.addFormats(formats);
 
@@ -15,7 +16,8 @@ if (existsSync(`${join(process.cwd(), "config", "schema")}.js`)) {
   userSchema = (await import(`${join(process.cwd(), "config", "schema")}.js`)).default;
 }
 
-const config = convict({ ...schema, ...userSchema });
+merge(schema, userSchema);
+const config = convict(schema);
 
 // we need to do this manually as using NODE_ENV as the default in schema produces some
 // weird results.

--- a/packages/fastify-podlet-server/package.json
+++ b/packages/fastify-podlet-server/package.json
@@ -39,6 +39,7 @@
     "fastify-plugin": "^4.5.0",
     "fastify-sandbox": "^0.11.0",
     "lit": "^2.6.1",
+    "lodash.merge": "^4.6.2",
     "minify-html-literals": "^1.3.5",
     "pino": "^8.10.0",
     "pino-pretty": "^9.2.0",


### PR DESCRIPTION
This PR makes it possible to override system config schemas rather than just values.

One use case for this is overriding the default for `assets.base` with a programmatic value which is built from `eik.json` but there could well be other such use cases.

It may also be that this is something we don't actually want/need but if that's the case, we can address later.