### PR TITLE
Add scripts and lazy loading

### DIFF
--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -455,14 +455,15 @@ Any values defined in this file, can be overridden for specific domains and envi
 | `metrics.timing.timeAllRoutes`    | false   |     | true/false      |
 | `metrics.timing.groupStatusCodes` | true    |     | true/false      |
 | `metrics.timing.enabled`          | true    |     | true/false      |
-| `metrics.enabled`                 | true    |     | true/false      |
 
 ### Assets Config
 
-| Key                  | Default   | ENV | Possible Values |
-| -------------------- | --------- | --- | --------------- |
-| `assets.base`        | "/static" |     |                 |
-| `assets.development` | false     |     | true/false      |
+| Key                  | Default     | ENV | Possible Values |
+| -------------------- | ----------- | --- | --------------- |
+| `assets.base`        | "/static"   |     |                 |
+| `assets.development` | false       |     | true/false      |
+| `assets.scripts`     | auto detect |     | true/false      |
+| `assets.lazy`        | auto detect |     | true/false      |
 
 ## Localisation
 

--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -69,6 +69,8 @@ Alternatively, an app might features such as config, localisation, additional se
   fallback.js
   server.js
   build.js
+  scripts.js
+  lazy.js
   package.json
   /config
     schema.js
@@ -99,12 +101,22 @@ This file must export a default export which is a LitElement class.
 This is the entrypoint for your apps fallback route. You may import dependencies from node_modules and additional source files from /src
 This file must export a default export which is a LitElement class.
 
+#### **scripts.js [optional]**
+
+This file can be used to define additional client side scripts that will be loaded. This is most useful for ssr-only app modes where you may need to add
+additional scripting to the SSR'd content.
+
+#### **lazy.js [optional]**
+
+This file can be used to lazy load additional client side scripts after the window load event has fired. This is useful for adding tracking scripts or other
+scripts that aren't needed on initial page load. Using this can help to get your initial bundle weight down and get pixels on the screen faster.
+
 #### **server.js [optional]**
 
 This is your way to hook into the app server by defining a Fastify plugin.
-You must export the a function that is a Fastify plugin. 
+You must export the a function that is a Fastify plugin.
 
-This function must be async 
+This function must be async
 
 ```js
 export default async function server(fastify, { config, podlet }) {
@@ -132,7 +144,7 @@ This file may import packages from node_modules or files from the /server folder
 This file can be used to hook into the Esbuild build process. It must export a function as a default function and return an array of Esbuild plugins
 
 ```js
-import plugin from 'some-esbuild-plugin';
+import plugin from "some-esbuild-plugin";
 export default () => [plugin()];
 ```
 
@@ -474,7 +486,7 @@ The app supports localisation out of the box. To start using it, you need to do 
 ```json5
 // locale/no.json
 {
-    "how_much_money": "Hvor mye penger har du i boden, egentlig?"
+  how_much_money: "Hvor mye penger har du i boden, egentlig?",
 }
 ```
 
@@ -483,9 +495,9 @@ The app supports localisation out of the box. To start using it, you need to do 
 ```js
 // content.js
 export default class Content extends PodiumPodletElement {
-    render() {
-        return html`<section>${this.t("how_much_money")}</section>`;
-    }
+  render() {
+    return html`<section>${this.t("how_much_money")}</section>`;
+  }
 }
 ```
 
@@ -499,7 +511,7 @@ Under the hood, lit-translate is used. [See the docs](https://www.npmjs.com/pack
 
 ## Customising The Build Pipeline [Advanced]
 
-Under the hood app builds and dev are provided by Esbuild. 
+Under the hood app builds and dev are provided by Esbuild.
 It's possible to hook into this build by creating a `build.js` file and defining an Esbuild plugin or plugins.
 
 ```js
@@ -513,9 +525,7 @@ export default ({ config }) => [
     // setup function gets passed a build object which has various lifecycle hooks
     setup(build) {
       // must provide a filter regex to determine which files in the build will be handled
-      build.onLoad({ filter: /(content|fallback)\.(ts|js)$/ }, async (args) => {
-        
-      });
+      build.onLoad({ filter: /(content|fallback)\.(ts|js)$/ }, async (args) => {});
     },
   },
 ];

--- a/packages/fastify-podlet-server/commands/dev.js
+++ b/packages/fastify-podlet-server/commands/dev.js
@@ -28,6 +28,8 @@ const OUTDIR = join(CWD, "dist");
 const CLIENT_OUTDIR = join(OUTDIR, "client");
 const CONTENT_FILEPATH = await resolve(join(CWD, "content.js"));
 const FALLBACK_FILEPATH = await resolve(join(CWD, "fallback.js"));
+const SCRIPTS_FILEPATH = await resolve(join(CWD, "scripts.js"));
+const LAZY_FILEPATH = await resolve(join(CWD, "lazy.js"));
 const SERVER_FILEPATH = await resolve(join(CWD, "server.js"));
 const BUILD_FILEPATH = await resolve(join(CWD, "build.js"));
 
@@ -37,6 +39,12 @@ if (existsSync(CONTENT_FILEPATH)) {
 }
 if (existsSync(FALLBACK_FILEPATH)) {
   entryPoints.push(FALLBACK_FILEPATH);
+}
+if (existsSync(SCRIPTS_FILEPATH)) {
+  entryPoints.push(SCRIPTS_FILEPATH);
+}
+if (existsSync(LAZY_FILEPATH)) {
+  entryPoints.push(LAZY_FILEPATH);
 }
 
 // support user defined plugins via a build.js file
@@ -69,7 +77,7 @@ const buildContext = await context({
 });
 
 // Chokidar provides super fast native file system watching
-const clientWatcher = chokidar.watch(["content.*", "fallback.*", "client/**/*"], {
+const clientWatcher = chokidar.watch(["content.*", "fallback.*", "scripts.*", "lazy.*", "client/**/*"], {
   persistent: true,
   followSymlinks: false,
   cwd: process.cwd(),

--- a/packages/fastify-podlet-server/lib/config-schema.js
+++ b/packages/fastify-podlet-server/lib/config-schema.js
@@ -131,6 +131,16 @@ export const schema = {
       format: Boolean,
       default: false,
     },
+    scripts: {
+      doc: "Whether scripts.js should be loaded. By default, the existence of the file scripts.js at project root determines this setting.",
+      format: Boolean,
+      default: false,
+    },
+    lazy: {
+      doc: "Whether lazy.js should be loaded. By default, the existence of the file lazy.js at project root determines this setting.",
+      format: Boolean,
+      default: false,
+    },
   },
 };
 

--- a/packages/fastify-podlet-server/lib/config.js
+++ b/packages/fastify-podlet-server/lib/config.js
@@ -50,6 +50,16 @@ if (existsSync(join(process.cwd(), "fallback.js"))) {
   config.load({ podlet: { fallback: "/fallback" } });
 }
 
+// auto detect scripts.js
+if (existsSync(join(process.cwd(), "scripts.js"))) {
+  config.load({ assets: { scripts: true } });
+}
+
+// auto detect lazy.js
+if (existsSync(join(process.cwd(), "lazy.js"))) {
+  config.load({ assets: { lazy: true } });
+}
+
 // load comon config overrides if provided
 // common.json is supported so that users can override core config without needing to override for multiple environments or domains
 if (existsSync(join(process.cwd(), `${join("config", "common")}.json`))) {


### PR DESCRIPTION
Proposes a solution for the use cases outlined in https://github.com/podium-lib/labs/issues/5

Adds new files, `scripts.js` and `lazy.js` that can be used to define additional scripts to be loaded.

* scripts.js is useful for ssr-only mode where you might want to write custom js on top of SSR'd markup and you don't want hydration (likely for perf reasons)
* lazy.js establishes a place to put tracking code and other code that is non critical path and loads scripts in using `import()` after window load.

@trygve-lie I know we were still thinking about this and what the right solution is but thought I would throw in a PR for it since its Friday and I can leave it sit over the weekend.