### PR TITLE
feat: Add custom error handler

### DIFF
--- a/packages/fastify-podlet-server/lib/fastify-podlet-plugin.js
+++ b/packages/fastify-podlet-server/lib/fastify-podlet-plugin.js
@@ -563,10 +563,6 @@ class PodletServerPlugin {
     return this.#podlet;
   }
 
-  get errors() {
-    return httpError;
-  }
-
   /**
    * We register the Podium podlet Fastify plugin here and pass it the podlet
    * and then collect the metrics

--- a/packages/fastify-podlet-server/package.json
+++ b/packages/fastify-podlet-server/package.json
@@ -38,6 +38,7 @@
     "fastify-metrics-js-response-timing": "^3.0.0",
     "fastify-plugin": "^4.5.0",
     "fastify-sandbox": "^0.11.0",
+    "http-errors": "^2.0.0",
     "lit": "^2.6.1",
     "lodash.merge": "^4.6.2",
     "minify-html-literals": "^1.3.5",


### PR DESCRIPTION
This adds a custom http error handler which take [http-errors](https://www.npmjs.com/package/http-errors) into account when constructing the http error page to send. This way its possible to control which http error to serve from where ever deeper down in the server code.

Podium do take http errors into account in the communication between layouts and podlets. A podlet can use http errors to signal to a layout what action to take if something fails in a podlet so we should make it easy to do this from the code the developer will write.

With this a user can then ex do stuff like this in a custom server.js file:

```js
import httpError from 'http-errors';

export default async function server(app, { config, podlet }) {
    app.setContentState(async () => {
        try {
          const res = await fetch('https://website');
          return res.json();
        } catch (error) {
          // This controls the http error page being served
          throw new httpError.ImATeapot();
        }
    });
}
```

And the app will serve an error page (with correct http error status code) like so if the `fetch()` method to an upstream service errors:

```json
{
    "statusCode": 418,
    "message": "I Am A Teapot"
}
```

Since this is based on passing on http-errors objects we might want to expose the internal http-errors module one way or another so the users don't have to import this them self (as the above example does). Maybe we should expose it along with the config, logger etc as such:

```js
export default async function server(app, { config, podlet, errors }) {
    app.setContentState(async () => {
        try {
          const res = await fetch('https://website');
          return res.json();
        } catch (error) {
          // This controls the http error page being served
          throw new errors.ImATeapot();
        }
    });
}
```
