### PR TITLE
expose error object to developers and add docs

### DIFF
--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -576,7 +576,7 @@ See the [Fastify docs](https://www.fastify.io/docs/latest/Reference/Validation-a
 Error handling has been added to enable developers to control application errors.
 If you throw an ordinary error from app.setContentState or app.setFallbackState this will result in the route serving a http 500 Internal Server error. 
 You can control which http errors the server should respond with by throwing a [http-errors](https://www.npmjs.com/package/http-errors) error. 
-In addition, an errors object with convenience methods has been added to make throwing different kinds of http errors more streamlined
+In addition, an errors object with http-errors convenience methods has been added to make throwing different kinds of http errors more streamlined
 See [http-errors](https://www.npmjs.com/package/http-errors) for available methods.
 
 Example

--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -571,7 +571,7 @@ export default {
 
 See the [Fastify docs](https://www.fastify.io/docs/latest/Reference/Validation-and-Serialization/) for more
 
-## Errors
+## Error handling
 
 Error handling has been added to enable developers to control application errors.
 If you throw an error from app.setContentState or app.setFallbackState this will result in a 500 error. 

--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -574,7 +574,7 @@ See the [Fastify docs](https://www.fastify.io/docs/latest/Reference/Validation-a
 ## Error handling
 
 Error handling has been added to enable developers to control application errors.
-If you throw an error from app.setContentState or app.setFallbackState this will result in a 500 error. 
+If you throw an ordinary error from app.setContentState or app.setFallbackState this will result in the route serving a http 500 Internal Server error. 
 You can control which http errors the server should respond with by throwing a [http-errors](https://www.npmjs.com/package/http-errors) error. 
 In addition, an errors object with convenience methods has been added to make throwing different kinds of http errors more streamlined
 See [http-errors](https://www.npmjs.com/package/http-errors) for available methods.

--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -573,7 +573,7 @@ See the [Fastify docs](https://www.fastify.io/docs/latest/Reference/Validation-a
 
 ## Errors
 
-Error handler has been added to enable developers to control application errors.
+Error handling has been added to enable developers to control application errors.
 If you throw an error from app.setContentState or app.setFallbackState this will result in a 500 error. 
 If you throw an error with the appropriate http status, this will result in a matching error.
 In addition, an errors object with convenience methods has been added to make throwing different kinds of http errors more streamlined

--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -570,3 +570,29 @@ export default {
 ```
 
 See the [Fastify docs](https://www.fastify.io/docs/latest/Reference/Validation-and-Serialization/) for more
+
+## Errors
+
+Error handler has been added to enable developers to control application errors.
+If you throw an error from app.setContentState or app.setFallbackState this will result in a 500 error. 
+If you throw an error with the appropriate http status, this will result in a matching error.
+In addition, an errors object with convenience methods has been added to make throwing different kinds of http errors more streamlined
+See [http-errors](https://www.npmjs.com/package/http-errors) for available methods.
+
+Example
+```js
+export default async function server(app, { errors }) {
+  app.setContentState(async () => {
+    throw errors.ImATeapot();
+  });
+}
+```
+
+response from the apps content route will be:
+
+```json
+{
+  "statusCode": 418,
+  "message": "I'm a Teapot"
+}
+```

--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -575,7 +575,7 @@ See the [Fastify docs](https://www.fastify.io/docs/latest/Reference/Validation-a
 
 Error handling has been added to enable developers to control application errors.
 If you throw an error from app.setContentState or app.setFallbackState this will result in a 500 error. 
-If you throw an error with the appropriate http status, this will result in a matching error.
+You can control which http errors the server should respond with by throwing a [http-errors](https://www.npmjs.com/package/http-errors) error. 
 In addition, an errors object with convenience methods has been added to make throwing different kinds of http errors more streamlined
 See [http-errors](https://www.npmjs.com/package/http-errors) for available methods.
 

--- a/packages/fastify-podlet-server/commands/dev.js
+++ b/packages/fastify-podlet-server/commands/dev.js
@@ -7,6 +7,7 @@ import { context } from "esbuild";
 import pino from "pino";
 import sandbox from "fastify-sandbox";
 import { start } from "@fastify/restartable";
+import httpError from 'http-errors';
 import config from "../lib/config.js";
 import fastifyPodletPlugin from "../lib/fastify-podlet-plugin.js";
 import resolve from "../lib/resolve.js";
@@ -105,7 +106,7 @@ const started = await start({
 
     // register user provided plugin using sandbox to enable reloading
     if (existsSync(SERVER_FILEPATH)) {
-      app.register(sandbox, { path: SERVER_FILEPATH, options: { prefix: config.get('app.base'), config, podlet: app.podlet } });
+      app.register(sandbox, { path: SERVER_FILEPATH, options: { prefix: config.get('app.base'), config, podlet: app.podlet, errors: httpError } });
     }
 
     done();

--- a/packages/fastify-podlet-server/commands/start.js
+++ b/packages/fastify-podlet-server/commands/start.js
@@ -3,6 +3,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import fastify from "fastify";
+import httpError from 'http-errors';
 import fastifyPodletPlugin from "../lib/fastify-podlet-plugin.js";
 import config from "../lib/config.js";
 
@@ -19,7 +20,7 @@ const podlet = fastifyApp.podlet;
 const serverFilePath = join(process.cwd(), "server.js");
 if (existsSync(serverFilePath)) {
   const server = (await import(serverFilePath)).default;
-  app.register(server, { prefix: config.get("app.base"), config, podlet });
+  app.register(server, { prefix: config.get("app.base"), config, podlet, errors: httpError });
 }
 
 try {

--- a/packages/fastify-podlet-server/lib/fastify-podlet-plugin.js
+++ b/packages/fastify-podlet-server/lib/fastify-podlet-plugin.js
@@ -489,14 +489,14 @@ class PodletServerPlugin {
    * Custom http error handler.
    * Takes http-errors into account when constructing which http error to serve.
    */
-  async errorHandler() {
+  errorHandler() {
     this.#fastify.setErrorHandler((error, request, reply) => {
       this.#logger.error(error);
       const err = httpError.isHttpError(error) ? error : new httpError.InternalServerError();
 
       if (err.headers) {
         for (const key in err.headers) {
-          reply.header(key, object[key]);
+          reply.header(key, err.headers[key]);
         }        
       }
 
@@ -627,7 +627,7 @@ class PodletServerPlugin {
         await this.serveAssets();
       }
 
-      await this.errorHandler();
+      this.errorHandler();
 
       this.metricStreams();
     };


### PR DESCRIPTION
This PR:

* Adds docs for error handler
* Exposes the error object to developers in the server plugin

```js
export default async function server(app, { errors }) {
  app.setContentState(async () => {
    throw errors.ImATeapot();
  });
}
```

* Fixes an error in header construction in the error handler
* Makes the error handling non async