### PR TITLE
exposes logger to developers via server plugin

### DIFF
--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -345,6 +345,17 @@ export default async function server(fastify, { config, podlet }) {
 }
 ```
 
+## Logger
+
+A [pino](https://github.com/pinojs/pino) logger is available in the server as follows
+
+```js
+export default async function server(app, { logger }) {
+  logger.info('hello from the server');
+}
+
+```
+
 ## Configuration
 
 The app comes with a built in configuration system based on [Convict](https://www.npmjs.com/package/convict).

--- a/packages/fastify-podlet-server/commands/dev.js
+++ b/packages/fastify-podlet-server/commands/dev.js
@@ -105,7 +105,7 @@ const started = await start({
 
     // register user provided plugin using sandbox to enable reloading
     if (existsSync(SERVER_FILEPATH)) {
-      app.register(sandbox, { path: SERVER_FILEPATH, options: { prefix: config.get('app.base'), config, podlet: app.podlet } });
+      app.register(sandbox, { path: SERVER_FILEPATH, options: { prefix: config.get('app.base'), logger: LOGGER, config, podlet: app.podlet } });
     }
 
     done();

--- a/packages/fastify-podlet-server/commands/start.js
+++ b/packages/fastify-podlet-server/commands/start.js
@@ -19,7 +19,7 @@ const podlet = fastifyApp.podlet;
 const serverFilePath = join(process.cwd(), "server.js");
 if (existsSync(serverFilePath)) {
   const server = (await import(serverFilePath)).default;
-  app.register(server, { prefix: config.get("app.base"), config, podlet });
+  app.register(server, { prefix: config.get("app.base"), logger: app.log, config, podlet });
 }
 
 try {


### PR DESCRIPTION
This PR makes the logger available using the same pattern as for config and podlet within the server.js file.

Fixes https://github.com/podium-lib/labs/issues/8

