### PR TITLE
strip values when no explicit validation provided. Display errors when validation provided

### DIFF
--- a/packages/fastify-podlet-server/README.md
+++ b/packages/fastify-podlet-server/README.md
@@ -553,6 +553,8 @@ Run tsc on the side to check types as part of your build.
 It is possible to add validation to your content and fallback routes via Fastify's route validation support. 
 Create a file called `schemas/content.js` or `schemas/fallback.js` to add validation and export an object of validation rules.
 
+Validation rules use [JSON Schema](https://json-schema.org) syntax
+
 Example
 ```js
 // schemas/content.js
@@ -560,13 +562,23 @@ export default {
   querystring: {
       type: 'object',
       properties: {
-        ids: {
-          type: 'array',
-          default: []
-        },
+        id: { type: 'integer' },
       },
+      required: ["id"],
     }
 }
 ```
 
-See the [Fastify docs](https://www.fastify.io/docs/latest/Reference/Validation-and-Serialization/) for more
+Note: To encourage best possible security, schemas are required in order to use headers, query parameters and route params.
+If you don't use any of these in your podlet, you don't need to define a schema file.
+
+In general, validation behaviour is as follows:
+
+If no schema file is defined for a given route:
+* All route params and query params are silently stripped and will not be accessible in your app.
+* All headers except the Podium context headers and the Accept-Encoding header are silently stripped and will not be accessible in your app.
+
+If a schema is defined for a given query param, route param or header:
+* The header will be available in your app and any errors in usage will result in your routes responding with a 400 bad request.
+
+See the [Fastify docs](https://www.fastify.io/docs/latest/Reference/Validation-and-Serialization/) for more examples and information regarding writing validation schemas.

--- a/packages/fastify-podlet-server/lib/fastify-podlet-plugin.js
+++ b/packages/fastify-podlet-server/lib/fastify-podlet-plugin.js
@@ -15,7 +15,9 @@ import esbuild from "esbuild";
 import Metrics from "@metrics/client";
 import { SemVer } from "semver";
 import compress from "@fastify/compress";
-import httpError from 'http-errors';
+import httpError from "http-errors";
+import merge from "lodash.merge";
+import Ajv from "ajv";
 import resolve from "./resolve.js";
 
 const require = createRequire(import.meta.url);
@@ -339,6 +341,67 @@ class PodletServerPlugin {
   }
 
   /**
+   * Sets up AJV validation for routes.
+   * If a schema is not provided for a route, query, params and header values will be stripped
+   */
+  validation() {
+    const schemaCompilers = {
+      body: new Ajv({
+        removeAdditional: "all",
+        coerceTypes: false,
+        allErrors: true,
+      }),
+      params: new Ajv({
+        removeAdditional: "all",
+        coerceTypes: true,
+        allErrors: true,
+      }),
+      querystring: new Ajv({
+        removeAdditional: "all",
+        coerceTypes: true,
+        allErrors: true,
+      }),
+      headers: new Ajv({
+        removeAdditional: "all",
+        coerceTypes: true,
+        allErrors: true,
+      }),
+    };
+
+    this.#fastify.setValidatorCompiler((req) => {
+      if (!req.httpPart) {
+        throw new Error("Missing httpPart");
+      }
+      const compiler = schemaCompilers[req.httpPart];
+      if (!compiler) {
+        throw new Error(`Missing compiler for ${req.httpPart}`);
+      }
+      return compiler.compile(req.schema);
+    });
+  }
+
+  get schemaDefaults() {
+    return {
+      headers: {
+        "podium-debug": { type: "boolean" },
+        "podium-locale": { type: "string", pattern: "^([a-z]{2})(-[A-Z]{2})?$" },
+        "podium-device-type": { enum: ["desktop", "mobile"] },
+        "podium-requested-by": { type: "string" },
+        "podium-mount-origin": {
+          type: "string",
+          pattern:
+            "^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*.?$",
+        },
+        "podium-mount-pathname": { type: "string", pattern: "^/[/.a-zA-Z0-9-]+$" },
+        "podium-public-pathname": { type: "string", pattern: "^/[/.a-zA-Z0-9-]+$" },
+        "accept-encoding": { type: "string" },
+      },
+      querystring: {},
+      params: {},
+    };
+  }
+
+  /**
    * Sets up a content route if needed.
    * Detects the presence of content.js or content.ts and if so, sets up the route.
    * A schema content file is also checked for at schemas/content and if found is used for validation
@@ -356,9 +419,10 @@ class PodletServerPlugin {
       // register user defined validation schema for route if provided
       // looks for a file named schemas/content.js and if present, imports
       // and provides to route.
-      const contentOptions = {};
+      const contentOptions = { schema: this.schemaDefaults };
       if (existsSync(CONTENT_SCHEMA_PATH)) {
-        contentOptions.schema = (await import(CONTENT_SCHEMA_PATH)).default;
+        const userSchema = (await import(CONTENT_SCHEMA_PATH)).default;
+        merge(contentOptions.schema, userSchema);
       }
 
       // builds content route path out of root + app name + the content path value in the podlet manifest
@@ -413,9 +477,10 @@ class PodletServerPlugin {
       // register user defined validation schema for route if provided
       // looks for a file named schemas/fallback.js and if present, imports
       // and provides to route.
-      const fallbackOptions = {};
+      const fallbackOptions = { schema: {} };
       if (existsSync(FALLBACK_SCHEMA_PATH)) {
-        fallbackOptions.schema = (await import(FALLBACK_SCHEMA_PATH)).default;
+        const userSchema = (await import(FALLBACK_SCHEMA_PATH)).default;
+        fallbackOptions.schema = merge(this.schemaDefaults, userSchema);
       }
 
       // builds fallback route path out of root + app name + the fallback path value in the podlet manifest
@@ -492,19 +557,36 @@ class PodletServerPlugin {
   async errorHandler() {
     this.#fastify.setErrorHandler((error, request, reply) => {
       this.#logger.error(error);
-      const err = httpError.isHttpError(error) ? error : new httpError.InternalServerError();
 
-      if (err.headers) {
-        for (const key in err.headers) {
-          reply.header(key, object[key]);
-        }        
+      let err;
+
+      // check if we have a validation error
+      if (error.validation) {
+        err = new httpError.BadRequest(`A validation error occurred when validating the ${error.validationContext}`);
+        err.errors = error.validation;
+        // validationContext will be 'body' or 'params' or 'headers' or 'query'
+        // reply.status(400).send({
+        //   statusCode: 400,
+        //   message: `A validation error occurred when validating the ${error.validationContext}...`,
+        //   errors: error.validation,
+        // });
+        // return reply;
+      } else {
+        err = httpError.isHttpError(error) ? error : new httpError.InternalServerError();
+
+        if (err.headers) {
+          for (const key in err.headers) {
+            reply.header(key, err.headers[key]);
+          }
+        }
       }
 
-      reply.status(err.status).send({ 
+      reply.status(err.status).send({
         statusCode: err.statusCode,
-        message: err.expose ? err.message : '',  
+        message: err.expose ? err.message : "",
+        errors: err.errors || undefined,
       });
-    })
+    });
   }
 
   /**
@@ -619,6 +701,7 @@ class PodletServerPlugin {
       await this.compression();
       await this.processExceptionHandlers();
       this.timingMetrics();
+      this.validation();
 
       if (this.#config.get("app.component")) {
         await this.contentRoute();

--- a/packages/fastify-podlet-server/package.json
+++ b/packages/fastify-podlet-server/package.json
@@ -31,6 +31,7 @@
     "@podium/fastify-podlet": "^3.0.0-next.3",
     "@podium/podlet": "^5.0.0-next.6",
     "abslog": "^2.4.0",
+    "ajv": "^8.12.0",
     "chokidar": "^3.5.3",
     "convict": "^6.2.4",
     "esbuild": "^0.17.6",


### PR DESCRIPTION
This PR enables strict validation of headers, querystrings and params.
Behaviour is as follows:
* if no validation is provided by the developer
  * all query string values are stripped
  * all headers except podium headers and compression headers are stripped
  * all params are stripped
* if validation is provided and an error occurs
  * validation errors are gathered and displayed in json format by the error handler

![Screen Shot 2023-03-06 at 17 29 11](https://user-images.githubusercontent.com/1177098/223020183-a222abe7-6089-4eb5-8168-44494d573fff.png)
