### PR TITLE
refactor commands to make testing easier and improve cli

### DIFF
--- a/packages/fastify-podlet-server/api/build.js
+++ b/packages/fastify-podlet-server/api/build.js
@@ -1,0 +1,75 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import esbuild from "esbuild";
+import resolve from "../lib/resolve.js";
+
+export async function build({ config, cwd = process.cwd() }) {
+  const NAME = /** @type {string} */ (/** @type {unknown} */ (config.get("app.name")));
+  const MODE = config.get("app.mode");
+  const OUTDIR = join(cwd, "dist");
+  const CLIENT_OUTDIR = join(OUTDIR, "client");
+  const CONTENT_FILEPATH = await resolve(join(cwd, "content.js"));
+  const FALLBACK_FILEPATH = await resolve(join(cwd, "fallback.js"));
+  const BUILD_FILEPATH = await resolve(join(cwd, "build.js"));
+  const CONTENT_ENTRYPOINT = join(OUTDIR, ".build", "content.js");
+  const FALLBACK_ENTRYPOINT = join(OUTDIR, ".build", "fallback.js");
+  const SCRIPTS_FILEPATH = await resolve(join(cwd, "scripts.js"));
+  const LAZY_FILEPATH = await resolve(join(cwd, "lazy.js"));
+
+  const entryPoints = [];
+  if (existsSync(CONTENT_FILEPATH)) {
+    // write entrypoint file to /dist/.build/content.js
+    mkdirSync(dirname(CONTENT_ENTRYPOINT), { recursive: true });
+    writeFileSync(
+      CONTENT_ENTRYPOINT,
+      `import "lit/experimental-hydrate-support.js";import Component from "${CONTENT_FILEPATH}";customElements.define("${NAME}-content",Component);`
+    );
+    if (MODE !== "ssr-only") {
+      entryPoints.push(CONTENT_ENTRYPOINT);
+    }
+  }
+  if (existsSync(FALLBACK_FILEPATH)) {
+    // write entrypoint file to /dist/.build/content.js
+    mkdirSync(dirname(FALLBACK_ENTRYPOINT), { recursive: true });
+    writeFileSync(
+      FALLBACK_ENTRYPOINT,
+      `import "lit/experimental-hydrate-support.js";import Component from "${FALLBACK_FILEPATH}";customElements.define("${NAME}-fallback",Component);`
+    );
+    if (MODE !== "ssr-only") {
+      entryPoints.push(FALLBACK_ENTRYPOINT);
+    }
+  }
+  if (existsSync(SCRIPTS_FILEPATH)) {
+    entryPoints.push(SCRIPTS_FILEPATH);
+  }
+  if (existsSync(LAZY_FILEPATH)) {
+    entryPoints.push(LAZY_FILEPATH);
+  }
+
+  // support user defined plugins via a build.js file
+  const plugins = [];
+  if (existsSync(BUILD_FILEPATH)) {
+    try {
+      const userDefinedBuild = (await import(BUILD_FILEPATH)).default;
+      const userDefinedPlugins = await userDefinedBuild({ config });
+      if (Array.isArray(userDefinedPlugins)) {
+        plugins.unshift(...userDefinedPlugins);
+      }
+    } catch (err) {
+      // noop
+    }
+  }
+
+  await esbuild.build({
+    entryNames: "[name]",
+    plugins,
+    entryPoints,
+    bundle: true,
+    format: "esm",
+    outdir: CLIENT_OUTDIR,
+    minify: true,
+    target: ["es2017"],
+    legalComments: `none`,
+    sourcemap: true,
+  });
+}

--- a/packages/fastify-podlet-server/api/dev.js
+++ b/packages/fastify-podlet-server/api/dev.js
@@ -1,0 +1,154 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import chokidar from "chokidar";
+import { context } from "esbuild";
+import pino from "pino";
+import sandbox from "fastify-sandbox";
+import { start } from "@fastify/restartable";
+import httpError from "http-errors";
+import fastifyPodletPlugin from "../lib/fastify-podlet-plugin.js";
+import resolve from "../lib/resolve.js";
+
+export async function dev({ config, cwd = process.cwd() }) {
+  config.set("assets.development", true);
+
+  const LOGGER = pino({
+    transport: {
+      target: "pino-pretty",
+      options: {
+        translateTime: "HH:MM:ss Z",
+        ignore: "pid,hostname",
+      },
+    },
+  });
+
+  const OUTDIR = join(cwd, "dist");
+  const CLIENT_OUTDIR = join(OUTDIR, "client");
+  const CONTENT_FILEPATH = await resolve(join(cwd, "content.js"));
+  const FALLBACK_FILEPATH = await resolve(join(cwd, "fallback.js"));
+  const SCRIPTS_FILEPATH = await resolve(join(cwd, "scripts.js"));
+  const LAZY_FILEPATH = await resolve(join(cwd, "lazy.js"));
+  const SERVER_FILEPATH = await resolve(join(cwd, "server.js"));
+  const BUILD_FILEPATH = await resolve(join(cwd, "build.js"));
+
+  const entryPoints = [];
+  if (existsSync(CONTENT_FILEPATH)) {
+    entryPoints.push(CONTENT_FILEPATH);
+  }
+  if (existsSync(FALLBACK_FILEPATH)) {
+    entryPoints.push(FALLBACK_FILEPATH);
+  }
+  if (existsSync(SCRIPTS_FILEPATH)) {
+    entryPoints.push(SCRIPTS_FILEPATH);
+  }
+  if (existsSync(LAZY_FILEPATH)) {
+    entryPoints.push(LAZY_FILEPATH);
+  }
+
+  // support user defined plugins via a build.js file
+  const plugins = [];
+  if (existsSync(BUILD_FILEPATH)) {
+    try {
+      const userDefinedBuild = (await import(BUILD_FILEPATH)).default;
+      const userDefinedPlugins = await userDefinedBuild({ config });
+      if (Array.isArray(userDefinedPlugins)) {
+        plugins.unshift(...userDefinedPlugins);
+      }
+    } catch (err) {
+      // noop
+    }
+  }
+
+  // create an esbuild context object for the client side build so that we
+  // can optimally rebundle whenever files change
+  const buildContext = await context({
+    entryPoints,
+    entryNames: "[name]",
+    bundle: true,
+    format: "esm",
+    outdir: CLIENT_OUTDIR,
+    minify: true,
+    target: ["es2017"],
+    legalComments: `none`,
+    sourcemap: true,
+    plugins,
+  });
+
+  // Chokidar provides super fast native file system watching
+  const clientWatcher = chokidar.watch(["content.*", "fallback.*", "scripts.*", "lazy.*", "client/**/*"], {
+    persistent: true,
+    followSymlinks: false,
+    cwd,
+  });
+
+  // rebuild the client side bundle whenever a client side related file changes
+  clientWatcher.on("change", async () => {
+    await buildContext.rebuild();
+  });
+
+  // Esbuild built in server which provides an SSE endpoint the client can subscribe to
+  // in order to know when to reload the page. Client subscribes with:
+  // new EventSource('http://localhost:6935/esbuild').addEventListener('change', () => { location.reload() });
+  await buildContext.serve({ port: 6935 });
+
+  // Create and start a development server
+  const started = await start({
+    logger: LOGGER,
+    // @ts-ignore
+    app: (app, opts, done) => {
+      if (config.get("app.base") !== "/") {
+        app.get("/", (request, reply) => {
+          reply.redirect(config.get("app.base"));
+        });
+      }
+
+      app.register(fastifyPodletPlugin, { config });
+
+      app.addHook("onError", (request, reply, error, done) => {
+        buildContext.dispose();
+        done();
+      });
+
+      // register user provided plugin using sandbox to enable reloading
+      if (existsSync(SERVER_FILEPATH)) {
+        app.register(sandbox, {
+          path: SERVER_FILEPATH,
+          options: { prefix: config.get("app.base"), logger: LOGGER, config, podlet: app.podlet, errors: httpError },
+        });
+      }
+
+      done();
+    },
+    port: config.get("app.port"),
+    ignoreTrailingSlash: true,
+  });
+
+  // Chokidar provides super fast native file system watching
+  // of server files. Either server.js or any js files inside a server folder
+  const serverWatcher = chokidar.watch(["server.*", "server/**/*"], {
+    persistent: true,
+    followSymlinks: false,
+    cwd,
+  });
+  serverWatcher.on("error", () => {
+    buildContext.dispose();
+  });
+
+  // restart the server whenever a server related file changes
+  serverWatcher.on("change", async () => {
+    try {
+      await started.restart();
+    } catch (err) {
+      console.log(err);
+      buildContext.dispose();
+    }
+  });
+
+  // start the server for the first time
+  try {
+    await started.listen();
+  } catch (err) {
+    console.log(err);
+    buildContext.dispose();
+  }
+}

--- a/packages/fastify-podlet-server/api/start.js
+++ b/packages/fastify-podlet-server/api/start.js
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import fastify from "fastify";
+import httpError from "http-errors";
+import fastifyPodletPlugin from "../lib/fastify-podlet-plugin.js";
+
+export async function start({ config, cwd = process.cwd() }) {
+  const app = fastify({ logger: true, ignoreTrailingSlash: true });
+  app.register(fastifyPodletPlugin, { prefix: config.get("app.base"), config });
+
+  /** @type {any} */
+  let fastifyApp = app;
+  /** @type {import("@podium/podlet").default} */
+  const podlet = fastifyApp.podlet;
+
+  // Load user server.js file if provided.
+  const serverFilePath = join(cwd, "server.js");
+  if (existsSync(serverFilePath)) {
+    const server = (await import(serverFilePath)).default;
+    app.register(server, { prefix: config.get("app.base"), logger: app.log, config, podlet, errors: httpError });
+  }
+
+  try {
+    await app.listen({ port: config.get("app.port") });
+  } catch (err) {
+    console.log(err);
+  }
+}

--- a/packages/fastify-podlet-server/cli.js
+++ b/packages/fastify-podlet-server/cli.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+"use strict";
+
+import { readFileSync } from "fs";
+import chalk from "chalk";
+import yargs from "yargs";
+import boxen from "boxen";
+import * as commands from "./commands/index.js";
+
+const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), { encoding: "utf8" }));
+const greeting = chalk.white.bold(`Podium Podlet Server (v${version})`);
+
+const msgBox = boxen(greeting, { padding: 0.5 });
+console.log(msgBox);
+
+yargs(process.argv.slice(2))
+  .command(commands.build)
+  .command(commands.start)
+  .command(commands.dev)
+  .example("podlet build", "Builds the podlet ready for production use")
+  .example("podlet serve", "Serves the podlet in production")
+  .example("podlet dev", "Builds and serves the podlet in development mode")
+  .demandCommand()
+  .wrap(150)
+  .version(false)
+  .help()
+  .argv;

--- a/packages/fastify-podlet-server/commands/build.js
+++ b/packages/fastify-podlet-server/commands/build.js
@@ -1,78 +1,27 @@
-#!/usr/bin/env node
+import { build } from "../api/build.js";
+import configuration from "../lib/config.js";
 
-/* eslint-disable no-console */
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import esbuild from "esbuild";
-import config from "../lib/config.js";
-import resolve from "../lib/resolve.js";
+export const command = "build";
 
-const NAME = /** @type {string} */ (/** @type {unknown} */ (config.get("app.name")));
-const MODE = config.get("app.mode");
-const CWD = process.cwd();
-const OUTDIR = join(CWD, "dist");
-const CLIENT_OUTDIR = join(OUTDIR, "client");
-const CONTENT_FILEPATH = await resolve(join(CWD, "content.js"));
-const FALLBACK_FILEPATH = await resolve(join(CWD, "fallback.js"));
-const BUILD_FILEPATH = await resolve(join(process.cwd(), "build.js"));
-const CONTENT_ENTRYPOINT = join(OUTDIR, ".build", "content.js");
-const FALLBACK_ENTRYPOINT = join(OUTDIR, ".build", "fallback.js");
-const SCRIPTS_FILEPATH = await resolve(join(CWD, "scripts.js"));
-const LAZY_FILEPATH = await resolve(join(CWD, "lazy.js"));
+export const aliases = ["b"];
 
-const entryPoints = [];
-if (existsSync(CONTENT_FILEPATH)) {
-  // write entrypoint file to /dist/.build/content.js
-  mkdirSync(dirname(CONTENT_ENTRYPOINT), { recursive: true });
-  writeFileSync(
-    CONTENT_ENTRYPOINT,
-    `import "lit/experimental-hydrate-support.js";import Component from "${CONTENT_FILEPATH}";customElements.define("${NAME}-content",Component);`
-  );
-  if (MODE !== "ssr-only") {
-    entryPoints.push(CONTENT_ENTRYPOINT);
-  }
-}
-if (existsSync(FALLBACK_FILEPATH)) {
-  // write entrypoint file to /dist/.build/content.js
-  mkdirSync(dirname(FALLBACK_ENTRYPOINT), { recursive: true });
-  writeFileSync(
-    FALLBACK_ENTRYPOINT,
-    `import "lit/experimental-hydrate-support.js";import Component from "${FALLBACK_FILEPATH}";customElements.define("${NAME}-fallback",Component);`
-  );
-  if (MODE !== "ssr-only") {
-    entryPoints.push(FALLBACK_ENTRYPOINT);
-  }
-}
-if (existsSync(SCRIPTS_FILEPATH)) {
-  entryPoints.push(SCRIPTS_FILEPATH);
-}
-if (existsSync(LAZY_FILEPATH)) {
-  entryPoints.push(LAZY_FILEPATH);
-}
+export const describe = `Build the app into the ./dist folder for production.`;
 
-// support user defined plugins via a build.js file
-const plugins = [];
-if (existsSync(BUILD_FILEPATH)) {
-  try {
-    const userDefinedBuild = (await import(BUILD_FILEPATH)).default;
-    const userDefinedPlugins = await userDefinedBuild({ config });
-    if (Array.isArray(userDefinedPlugins)) {
-      plugins.unshift(...userDefinedPlugins);
-    }
-  } catch (err) {
-    // noop
-  }
-}
+export const builder = (yargs) => {
+  yargs.example("podlet build");
 
-await esbuild.build({
-  entryNames: "[name]",
-  plugins,
-  entryPoints,
-  bundle: true,
-  format: "esm",
-  outdir: CLIENT_OUTDIR,
-  minify: true,
-  target: ["es2017"],
-  legalComments: `none`,
-  sourcemap: true,
-});
+  yargs.options({
+    cwd: {
+      describe: `Alter the current working directory. Defaults to the directory where the command is being run.`,
+      default: process.cwd(),
+    },
+  });
+
+  return yargs.argv;
+};
+
+export const handler = async (argv) => {
+  const { cwd } = argv;
+  const config = await configuration({ cwd });
+  await build({ config, cwd });
+};

--- a/packages/fastify-podlet-server/commands/dev.js
+++ b/packages/fastify-podlet-server/commands/dev.js
@@ -1,155 +1,27 @@
-#!/usr/bin/env node
+import { dev } from "../api/dev.js"
+import configuration from "../lib/config.js";
 
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import chokidar from "chokidar";
-import { context } from "esbuild";
-import pino from "pino";
-import sandbox from "fastify-sandbox";
-import { start } from "@fastify/restartable";
-import httpError from 'http-errors';
-import config from "../lib/config.js";
-import fastifyPodletPlugin from "../lib/fastify-podlet-plugin.js";
-import resolve from "../lib/resolve.js";
+export const command = "dev";
 
-config.set("assets.development", true);
+export const aliases = ["d"];
 
-const LOGGER = pino({
-  transport: {
-    target: "pino-pretty",
-    options: {
-      translateTime: "HH:MM:ss Z",
-      ignore: "pid,hostname",
-    },
-  },
-});
+export const describe = `Build and start the app, watch for file changes (live reload).`;
 
-const CWD = process.cwd();
-const OUTDIR = join(CWD, "dist");
-const CLIENT_OUTDIR = join(OUTDIR, "client");
-const CONTENT_FILEPATH = await resolve(join(CWD, "content.js"));
-const FALLBACK_FILEPATH = await resolve(join(CWD, "fallback.js"));
-const SCRIPTS_FILEPATH = await resolve(join(CWD, "scripts.js"));
-const LAZY_FILEPATH = await resolve(join(CWD, "lazy.js"));
-const SERVER_FILEPATH = await resolve(join(CWD, "server.js"));
-const BUILD_FILEPATH = await resolve(join(CWD, "build.js"));
+export const builder = (yargs) => {
+  yargs.example("podlet dev");
 
-const entryPoints = [];
-if (existsSync(CONTENT_FILEPATH)) {
-  entryPoints.push(CONTENT_FILEPATH);
-}
-if (existsSync(FALLBACK_FILEPATH)) {
-  entryPoints.push(FALLBACK_FILEPATH);
-}
-if (existsSync(SCRIPTS_FILEPATH)) {
-  entryPoints.push(SCRIPTS_FILEPATH);
-}
-if (existsSync(LAZY_FILEPATH)) {
-  entryPoints.push(LAZY_FILEPATH);
-}
-
-// support user defined plugins via a build.js file
-const plugins = [];
-if (existsSync(BUILD_FILEPATH)) {
-  try {
-    const userDefinedBuild = (await import(BUILD_FILEPATH)).default;
-    const userDefinedPlugins = await userDefinedBuild({ config });
-    if (Array.isArray(userDefinedPlugins)) {
-      plugins.unshift(...userDefinedPlugins);
+  yargs.options({
+    cwd: {
+      describe: `Alter the current working directory. Defaults to the directory where the command is being run.`,
+      default: process.cwd(),
     }
-  } catch (err) {
-    // noop
-  }
-}
+  });
 
-// create an esbuild context object for the client side build so that we
-// can optimally rebundle whenever files change
-const buildContext = await context({
-  entryPoints,
-  entryNames: "[name]",
-  bundle: true,
-  format: "esm",
-  outdir: CLIENT_OUTDIR,
-  minify: true,
-  target: ["es2017"],
-  legalComments: `none`,
-  sourcemap: true,
-  plugins,
-});
+  return yargs.argv;
+};
 
-// Chokidar provides super fast native file system watching
-const clientWatcher = chokidar.watch(["content.*", "fallback.*", "scripts.*", "lazy.*", "client/**/*"], {
-  persistent: true,
-  followSymlinks: false,
-  cwd: process.cwd(),
-});
-
-// rebuild the client side bundle whenever a client side related file changes
-clientWatcher.on("change", async () => {
-  await buildContext.rebuild();
-});
-
-// Esbuild built in server which provides an SSE endpoint the client can subscribe to
-// in order to know when to reload the page. Client subscribes with:
-// new EventSource('http://localhost:6935/esbuild').addEventListener('change', () => { location.reload() });
-await buildContext.serve({ port: 6935 });
-
-// Create and start a development server
-const started = await start({
-  logger: LOGGER,
-  // @ts-ignore
-  app: (app, opts, done) => {
-    if (config.get('app.base') !== "/") {
-      app.get("/", (request, reply) => {
-        reply.redirect(config.get('app.base'));
-      })
-    }
-
-    app.register(fastifyPodletPlugin, { config });
-
-    app.addHook('onError', (request, reply, error, done) => {
-      buildContext.dispose();
-      done();
-    })
-
-    // register user provided plugin using sandbox to enable reloading
-    if (existsSync(SERVER_FILEPATH)) {
-      app.register(sandbox, { path: SERVER_FILEPATH, options: { prefix: config.get('app.base'), logger: LOGGER, config, podlet: app.podlet, errors: httpError } });
-    }
-
-    done();
-  },
-  port: config.get("app.port"),
-  ignoreTrailingSlash: true,
-});
-
-// Chokidar provides super fast native file system watching
-// of server files. Either server.js or any js files inside a server folder
-const serverWatcher = chokidar.watch(["server.*", "server/**/*"], {
-  persistent: true,
-  followSymlinks: false,
-  cwd: process.cwd(),
-});
-serverWatcher.on('error', () => {
-  buildContext.dispose();
-})
-
-// restart the server whenever a server related file changes
-serverWatcher.on("change", async () => {
-  try {
-    await started.restart();
-  } catch (err) {
-    console.log(err);
-    buildContext.dispose();
-  }
-});
-
-// start the server for the first time
-try {
-  await started.listen();
-} catch (err) {
-  console.log(err);
-  buildContext.dispose();
-}
-
-
+export const handler = async (argv) => {
+  const { cwd } = argv;
+  const config = await configuration({ cwd });
+  await dev({ config, cwd });
+};

--- a/packages/fastify-podlet-server/commands/index.js
+++ b/packages/fastify-podlet-server/commands/index.js
@@ -1,0 +1,3 @@
+export * as build from "./build.js";
+export * as start from "./start.js";
+export * as dev from "./dev.js";

--- a/packages/fastify-podlet-server/lib/config.js
+++ b/packages/fastify-podlet-server/lib/config.js
@@ -7,72 +7,73 @@ import merge from "lodash.merge";
 
 convict.addFormats(formats);
 
-// load additional config if provided
-// users can define a config schema file with addition config options and this
-// will be merged into the base config and can then be overridden as needed
-// for specific environments, hosts or globally.
-let userSchema = {};
-if (existsSync(`${join(process.cwd(), "config", "schema")}.js`)) {
-  userSchema = (await import(`${join(process.cwd(), "config", "schema")}.js`)).default;
+export default async function configuration({ cwd = process.cwd() }) {
+  // load additional config if provided
+  // users can define a config schema file with addition config options and this
+  // will be merged into the base config and can then be overridden as needed
+  // for specific environments, hosts or globally.
+  let userSchema = {};
+  if (existsSync(`${join(cwd, "config", "schema")}.js`)) {
+    userSchema = (await import(`${join(cwd, "config", "schema")}.js`)).default;
+  }
+
+  merge(schema, userSchema);
+  const config = convict(schema);
+
+  // we need to do this manually as using NODE_ENV as the default in schema produces some
+  // weird results.
+  // essentially, everytime you call load, NODE_ENV overwrites the value of app.env again.
+  if (process.env.NODE_ENV === "development") {
+    config.set("app.env", "local");
+  }
+
+  // The expectation is that HOST and NODE_ENV env vars will be set in production
+  const host = config.get("app.host");
+  const env = config.get("app.env");
+
+  // programmatically set defaults for cases
+  // locally, default to development mode
+  if (env === "local") {
+    config.load({ app: { development: true } });
+  }
+
+  // name defaults to the name field in package.json
+  const { name } = JSON.parse(await readFile(join(cwd, "package.json"), { encoding: "utf8" }));
+  // makes it possible to change the path that the app is mounted at by changing config.
+  // {
+  //   "app": { "base": "/" }
+  // }
+  config.load({ app: { name, base: `/${name}` } });
+
+  // if a fallback is defined, set the fallback path
+  // this is so that the Podlet object fallback setting does not get set if no fallback is defined.
+  if (existsSync(join(cwd, "fallback.js"))) {
+    config.load({ podlet: { fallback: "/fallback" } });
+  }
+
+  // auto detect scripts.js
+  if (existsSync(join(cwd, "scripts.js"))) {
+    config.load({ assets: { scripts: true } });
+  }
+
+  // auto detect lazy.js
+  if (existsSync(join(cwd, "lazy.js"))) {
+    config.load({ assets: { lazy: true } });
+  }
+
+  // load comon config overrides if provided
+  // common.json is supported so that users can override core config without needing to override for multiple environments or hosts
+  if (existsSync(join(cwd, `${join("config", "common")}.json`))) {
+    config.loadFile(join(cwd, `${join("config", "common")}.json`));
+  }
+
+  // load specific overrides if provided
+  // fine grained config overrides. Hosts and env overrides etc.
+  if (existsSync(join(cwd, `${join("config", "hosts", host, "config")}.${env}.json`))) {
+    config.loadFile(join(cwd, `${join("config", "hosts", host, "config")}.${env}.json`));
+  }
+
+  // once all is setup, validate.
+  config.validate();
+  return config;
 }
-
-merge(schema, userSchema);
-const config = convict(schema);
-
-// we need to do this manually as using NODE_ENV as the default in schema produces some
-// weird results.
-// essentially, everytime you call load, NODE_ENV overwrites the value of app.env again.
-if (process.env.NODE_ENV === "development") {
-  config.set("app.env", "local");
-}
-
-// The expectation is that HOST and NODE_ENV env vars will be set in production
-const host = config.get("app.host");
-const env = config.get("app.env");
-
-// programmatically set defaults for cases
-// locally, default to development mode
-if (env === "local") {
-  config.load({ app: { development: true } });
-}
-
-// name defaults to the name field in package.json
-const { name } = JSON.parse(await readFile(join(process.cwd(), "package.json"), { encoding: "utf8" }));
-// makes it possible to change the path that the app is mounted at by changing config.
-// {
-//   "app": { "base": "/" }
-// }
-config.load({ app: { name, base: `/${name}` } });
-
-// if a fallback is defined, set the fallback path
-// this is so that the Podlet object fallback setting does not get set if no fallback is defined.
-if (existsSync(join(process.cwd(), "fallback.js"))) {
-  config.load({ podlet: { fallback: "/fallback" } });
-}
-
-// auto detect scripts.js
-if (existsSync(join(process.cwd(), "scripts.js"))) {
-  config.load({ assets: { scripts: true } });
-}
-
-// auto detect lazy.js
-if (existsSync(join(process.cwd(), "lazy.js"))) {
-  config.load({ assets: { lazy: true } });
-}
-
-// load comon config overrides if provided
-// common.json is supported so that users can override core config without needing to override for multiple environments or hosts
-if (existsSync(join(process.cwd(), `${join("config", "common")}.json`))) {
-  config.loadFile(join(process.cwd(), `${join("config", "common")}.json`));
-}
-
-// load specific overrides if provided
-// fine grained config overrides. Hosts and env overrides etc.
-if (existsSync(join(process.cwd(), `${join("config", "hosts", host, "config")}.${env}.json`))) {
-  config.loadFile(join(process.cwd(), `${join("config", "hosts", host, "config")}.${env}.json`));
-}
-
-// once all is setup, validate.
-config.validate();
-
-export default config;

--- a/packages/fastify-podlet-server/package.json
+++ b/packages/fastify-podlet-server/package.json
@@ -3,12 +3,16 @@
   "version": "0.0.8",
   "type": "module",
   "bin": {
-    "podlet-dev": "./commands/dev.js",
-    "podlet-start": "./commands/start.js",
-    "podlet-build": "./commands/build.js"
+    "podlet": "./cli.js"
   },
   "exports": {
-    "./config": "./lib/config.js"
+    "./config": "./lib/config.js",
+    "./schema": "./lib/config-schema.js",
+    "./plugin": "./lib/fastify-podlet-plugin.js",
+    "./commands": "./commands/index.js",
+    "./build": "./commands/build.js",
+    "./start": "./commands/start.js",
+    "./dev": "./commands/dev.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -32,6 +36,8 @@
     "@podium/podlet": "^5.0.0-next.6",
     "abslog": "^2.4.0",
     "ajv": "^8.12.0",
+    "boxen": "^7.0.2",
+    "chalk": "^5.2.0",
     "chokidar": "^3.5.3",
     "convict": "^6.2.4",
     "esbuild": "^0.17.6",
@@ -46,7 +52,8 @@
     "pino": "^8.10.0",
     "pino-pretty": "^9.2.0",
     "prom-client": "^14.1.1",
-    "semver": "^7.3.8"
+    "semver": "^7.3.8",
+    "yargs": "^17.7.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR breaks the cli commands apart into programmatic api + cli so that the programmatic api can be mode easily put under test (to do after this PR)

directory structure becomes:

```
/cli.js <-- entry point to cli
/commands <-- contains each command for the cli
  /build.js
  /dev.js
  /start.js
  /index.js
/api <-- contains the programmatic implementations of the commands
  /build.js
  /dev.js
  /start.js
```

This makes it possible to run a command via either:
```
npx podlet dev
npx podlet start
npx podlet build
```

OR

```
import { build } from "@podium/podlet-server/build";
import configuration from "@podium/podlet-server/config";

const config = await configuration();
await build({ config });
```

For testing, this will make it possible to control the config that is passed into the build, dev and start commands.

The other thing this PR does is use yargs to build the cli commands which produces a nice interface and gives a help menu etc.

![Screen Shot 2023-03-07 at 11 22 04](https://user-images.githubusercontent.com/1177098/223256031-9eeb6d0f-d9ca-4379-a8b3-1de761950a62.png)
