### PR TITLE
Support typescript in server and build files

### DIFF
--- a/packages/fastify-podlet-server/api/dev.js
+++ b/packages/fastify-podlet-server/api/dev.js
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { join } from "node:path";
 import chokidar from "chokidar";
 import { context } from "esbuild";
@@ -7,7 +6,7 @@ import sandbox from "fastify-sandbox";
 import { start } from "@fastify/restartable";
 import httpError from "http-errors";
 import fastifyPodletPlugin from "../lib/plugin.js";
-import resolve from "../lib/resolve.js";
+import PathResolver from "../lib/path.js";
 
 const joinURLPathSegments = (...segments) => {
   return segments.join("/").replace(/[\/]+/g, "/");
@@ -26,37 +25,36 @@ export async function dev({ config, cwd = process.cwd() }) {
     },
   });
 
+  const resolver = new PathResolver({ cwd, development: config.get("app.development") });
+
   const OUTDIR = join(cwd, "dist");
   const CLIENT_OUTDIR = join(OUTDIR, "client");
-  const CONTENT_FILEPATH = await resolve(join(cwd, "content.js"));
-  const FALLBACK_FILEPATH = await resolve(join(cwd, "fallback.js"));
-  const SCRIPTS_FILEPATH = await resolve(join(cwd, "scripts.js"));
-  const LAZY_FILEPATH = await resolve(join(cwd, "lazy.js"));
-  const SERVER_FILEPATH = await resolve(join(cwd, "server.js"));
-  const BUILD_FILEPATH = await resolve(join(cwd, "build.js"));
-
-  let contentFileExists = false;
+  const CONTENT_FILEPATH = await resolver.resolve("./content");
+  const FALLBACK_FILEPATH = await resolver.resolve("./fallback");
+  const SCRIPTS_FILEPATH = await resolver.resolve("./scripts");
+  const LAZY_FILEPATH = await resolver.resolve("./lazy");
+  const BUILD_FILEPATH = await resolver.resolve("./build");
+  const SERVER_FILEPATH = await resolver.buildAndResolve("./server");
 
   const entryPoints = [];
-  if (existsSync(CONTENT_FILEPATH)) {
-    entryPoints.push(CONTENT_FILEPATH);
-    contentFileExists = true;
+  if (CONTENT_FILEPATH.exists) {
+    entryPoints.push(CONTENT_FILEPATH.path);
   }
-  if (existsSync(FALLBACK_FILEPATH)) {
-    entryPoints.push(FALLBACK_FILEPATH);
+  if (FALLBACK_FILEPATH.exists) {
+    entryPoints.push(FALLBACK_FILEPATH.path);
   }
-  if (existsSync(SCRIPTS_FILEPATH)) {
-    entryPoints.push(SCRIPTS_FILEPATH);
+  if (SCRIPTS_FILEPATH.exists) {
+    entryPoints.push(SCRIPTS_FILEPATH.path);
   }
-  if (existsSync(LAZY_FILEPATH)) {
-    entryPoints.push(LAZY_FILEPATH);
+  if (LAZY_FILEPATH.exists) {
+    entryPoints.push(LAZY_FILEPATH.path);
   }
 
   // support user defined plugins via a build.js file
   const plugins = [];
-  if (existsSync(BUILD_FILEPATH)) {
+  if (BUILD_FILEPATH.exists) {
     try {
-      const userDefinedBuild = (await import(BUILD_FILEPATH)).default;
+      const userDefinedBuild = (await resolver.import(BUILD_FILEPATH)).default;
       const userDefinedPlugins = await userDefinedBuild({ config });
       if (Array.isArray(userDefinedPlugins)) {
         plugins.unshift(...userDefinedPlugins);
@@ -104,14 +102,14 @@ export async function dev({ config, cwd = process.cwd() }) {
     // @ts-ignore
     app: (app, opts, done) => {
       // if no content file yet defined, redirect to manifest file
-      if (!contentFileExists) {
+      if (!CONTENT_FILEPATH.exists) {
         app.get("/", (request, reply) => {
           reply.redirect(join(config.get("app.base"), config.get("podlet.manifest")));
         });
       }
 
       // if content file is defined, and content url doesn't resolve to /, redirect to content route
-      if (joinURLPathSegments(config.get("app.base"), config.get("podlet.content")) !== "/" && contentFileExists) {
+      if (joinURLPathSegments(config.get("app.base"), config.get("podlet.content")) !== "/" && CONTENT_FILEPATH.exists) {
         app.get("/", (request, reply) => {
           reply.redirect(join(config.get("app.base"), config.get("podlet.content")));
         });
@@ -144,9 +142,10 @@ export async function dev({ config, cwd = process.cwd() }) {
       });
 
       // register user provided plugin using sandbox to enable reloading
-      if (existsSync(SERVER_FILEPATH)) {
+      // Load user server.js file if provided.
+      if (SERVER_FILEPATH.exists) {
         app.register(sandbox, {
-          path: SERVER_FILEPATH,
+          path: SERVER_FILEPATH.path,
           options: { prefix: config.get("app.base"), logger: LOGGER, config, podlet: app.podlet, errors: httpError },
         });
       }

--- a/packages/fastify-podlet-server/lib/path.js
+++ b/packages/fastify-podlet-server/lib/path.js
@@ -1,0 +1,127 @@
+import { stat } from "node:fs/promises";
+import { isAbsolute, join, parse } from "node:path";
+import esbuild from "esbuild";
+
+/**
+ * @typedef {{ exists: boolean, originalPath: string, cwd: string, typescript: boolean, javascript: boolean, path: string }} Resolution
+ */
+
+export default class FileUtilities {
+  constructor({ development = false, cwd = process.cwd() } = {}) {
+    this.development = development;
+    this.cwd = cwd;
+  }
+
+  /**
+   * Given a path with .js extension, resolves a path resolution object
+   * Typescript files are detected and converted to js files in dist folder before resolution
+   * If both paths resolve, error is thrown
+   * If no paths resolve, resolution.exists will be false
+   * @param {string} path
+   * @returns {Promise<Resolution>}
+   */
+  async resolve(path) {
+    /** @type {Resolution} */
+    const resolution = {
+      exists: false,
+      originalPath: path,
+      cwd: this.cwd,
+      typescript: false,
+      javascript: false,
+      path: isAbsolute(path) ? path : join(this.cwd, path),
+    };
+
+    // support not specifying .js extension which offers a more intuitive api surface.
+    // ie. resolve("./content") will resolve both ts and js files which is more understandable
+    // thatn resolve("./content.js") resolving to a .ts file.
+    if (parse(resolution.path).ext === '') resolution.path = resolution.path + ".js";
+
+    const meta = parse(resolution.path);
+    const tsPath = join(meta.dir, `${meta.name}.ts`);
+    const [statsJs, statsTs] = await Promise.all([stat(resolution.path).catch(() => {}), stat(tsPath).catch(() => {})]);
+    if (statsJs && statsTs) {
+      throw new Error(
+        `.ts and .js versions of file exist for file ${resolution.path}. Please use either Typescript OR JavaScript.`
+      );
+    }
+
+    if (!statsJs && !statsTs) {
+      // no files to resolve
+      return resolution;
+    } else {
+      resolution.exists = true;
+    }
+
+    if (statsJs) {
+      resolution.javascript = true;
+      if (statsJs.isDirectory()) {
+        throw new Error(`${resolution.path} is a directory, file expected.`);
+      }
+      if (statsJs.isFile()) {
+        return resolution;
+      }
+    }
+
+    if (statsTs) {
+      resolution.typescript = true;
+      resolution.path = tsPath;
+      if (statsTs.isDirectory()) {
+        throw new Error(`${tsPath} is a directory, file expected.`);
+      }
+      if (statsTs.isFile()) {
+        return resolution;
+      }
+    }
+
+    throw new Error(`Unable to resolve file at path ${path}`);
+  }
+
+  /**
+   *
+   * @param {string} path
+   * @returns {Promise<Resolution>} resolution
+   */
+  async buildAndResolve(path) {
+    const resolution = await this.resolve(path);
+
+    // if a file resolves to a typescript file, bundle that file into dist, and update the resolution object before
+    // returning it.
+    if (resolution.typescript) {
+      const outfile = join(this.cwd, "dist", "server", `${parse(path).name}.js`);
+      try {
+        await esbuild.build({
+          entryPoints: [resolution.path],
+          bundle: true,
+          format: "esm",
+          outfile,
+          minify: false,
+          legalComments: `none`,
+          sourcemap: this.development ? "inline" : false,
+        });
+      } catch (err) {
+        throw new Error(`Unable to convert TS file to JS for path ${resolution.path}`);
+      }
+
+      resolution.path = outfile;
+    }
+    return resolution;
+  }
+
+  /**
+   * Given a path to a .js or .ts file, or a Resolution object, import file.
+   * If file is a Typescript file, bundle to dist/server and then import bundled file
+   * If file is a JavaScript, simply import it.
+   * @param {Resolution | string} path
+   * @returns {Promise<any>}
+   */
+  async import(path) {
+    let resolution;
+    if (typeof path === 'string') {
+      resolution = await this.buildAndResolve(path);
+    } else {
+      resolution = /** @type {Resolution} */(path);
+    }
+    if (resolution.exists) return import(resolution.path);
+    throw new Error(`Unable to import file at path ${resolution.path}. File does not exist.`)
+  }
+}

--- a/packages/fastify-podlet-server/lib/path.js
+++ b/packages/fastify-podlet-server/lib/path.js
@@ -120,6 +120,9 @@ export default class FileUtilities {
       resolution = await this.buildAndResolve(path);
     } else {
       resolution = /** @type {Resolution} */(path);
+      if (resolution.typescript) {
+        resolution = await this.buildAndResolve(resolution.originalPath);
+      }
     }
     if (resolution.exists) return import(resolution.path);
     throw new Error(`Unable to import file at path ${resolution.path}. File does not exist.`)

--- a/packages/fastify-podlet-server/test/lib/path.test.js
+++ b/packages/fastify-podlet-server/test/lib/path.test.js
@@ -1,0 +1,125 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { test, beforeEach, afterEach } from "tap";
+import PathResolver from "../../lib/path.js";
+import { existsSync } from "node:fs";
+
+const tmp = join(tmpdir(), "./path.test.js");
+
+beforeEach(async () => {
+  await mkdir(tmp);
+  await writeFile(join(tmp, "javascript.js"), "export const script = true;");
+  await writeFile(join(tmp, "typescript.ts"), "export const script = true;");
+  await mkdir(join(tmp, "dist"));
+  await writeFile(join(tmp, "package.json"), JSON.stringify({ name: "test-app", type: "module" }));
+});
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+test("JavaScript file resolution for a file that exists", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const resolution = await resolver.resolve("./javascript.js");
+  t.equal(resolution.javascript, true);
+  t.equal(resolution.typescript, false);
+  t.equal(resolution.path, join(tmp, "./javascript.js"));
+  t.equal(resolution.exists, true);
+  t.equal(resolution.originalPath, "./javascript.js");
+  t.equal(resolution.cwd, tmp);
+});
+
+test("JavaScript file resolution via absolute path", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const resolution = await resolver.resolve(join(tmp, "./javascript.js"));
+  t.equal(resolution.javascript, true);
+  t.equal(resolution.typescript, false);
+  t.equal(resolution.path, join(tmp, "./javascript.js"));
+  t.equal(resolution.exists, true);
+  t.equal(resolution.originalPath, join(tmp, "./javascript.js"));
+  t.equal(resolution.cwd, tmp);
+});
+
+test("Non existent file", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const resolution = await resolver.resolve("./fake.js");
+  t.equal(resolution.javascript, false);
+  t.equal(resolution.typescript, false);
+  t.equal(resolution.path, join(tmp, "./fake.js"));
+  t.equal(resolution.exists, false);
+  t.equal(resolution.originalPath, "./fake.js");
+  t.equal(resolution.cwd, tmp);
+});
+
+test("Typescript file", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const resolution = await resolver.resolve("./typescript.js");
+  t.equal(resolution.javascript, false);
+  t.equal(resolution.typescript, true);
+  t.equal(resolution.path, join(tmp, "./typescript.ts"));
+  t.equal(resolution.exists, true);
+  t.equal(resolution.originalPath, "./typescript.js");
+  t.equal(resolution.cwd, tmp);
+});
+
+test("Typescript and Javascript file throws", async (t) => {
+  await writeFile(join(tmp, "javascript.ts"), "export const script = true;");
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  try {
+    await resolver.resolve("./javascript.js");
+  } catch (err) {
+    t.match(err.message, ".ts and .js versions of file exist for file");
+    t.match(err.message, "Please use either Typescript OR JavaScript");
+  }
+});
+
+test(".buildAndResolve resolves Javascript the same as for .resolve", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  t.equal((await resolver.resolve("./javascript.js")).path, (await resolver.buildAndResolve("./javascript.js")).path);
+});
+
+test(".buildAndResolve builds and then resolves Typescript to Javascript", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const resolution = await resolver.buildAndResolve("./typescript.js");
+  t.equal(resolution.path, join(tmp, "dist", "server", "typescript.js"));
+  t.ok(existsSync(resolution.path));
+});
+
+test("Import JavaScript file using a path string", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const { script } = await resolver.import("./javascript.js");
+  t.equal(script, true);
+});
+
+test("Import TypeScript file using a path string", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const { script } = await resolver.import("./typescript.js");
+  t.equal(script, true);
+});
+
+test("Import JavaScript file using a resolution object", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const resolution = await resolver.resolve("./javascript.js");
+  const { script } = await resolver.import(resolution);
+  t.equal(script, true);
+});
+
+test("Import TypeScript file using a path string", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const resolution = await resolver.buildAndResolve("./typescript.js");
+  const { script } = await resolver.import(resolution);
+  t.equal(script, true);
+});
+
+test("Import JavaScript file using a path string without extension", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const { script } = await resolver.import("./javascript");
+  t.equal(script, true);
+});
+
+test("Import TypeScript file using a path string without extension", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const { script } = await resolver.import("./typescript");
+  t.equal(script, true);
+});

--- a/packages/fastify-podlet-server/test/lib/path.test.js
+++ b/packages/fastify-podlet-server/test/lib/path.test.js
@@ -105,9 +105,16 @@ test("Import JavaScript file using a resolution object", async (t) => {
   t.equal(script, true);
 });
 
-test("Import TypeScript file using a path string", async (t) => {
+test("Import TypeScript file using a buildAndResolve resolution object", async (t) => {
   const resolver = new PathResolver({ cwd: tmp, development: false });
   const resolution = await resolver.buildAndResolve("./typescript.js");
+  const { script } = await resolver.import(resolution);
+  t.equal(script, true);
+});
+
+test("Import TypeScript file using a resolution object", async (t) => {
+  const resolver = new PathResolver({ cwd: tmp, development: false });
+  const resolution = await resolver.resolve("./typescript.js");
   const { script } = await resolver.import(resolution);
   t.equal(script, true);
 });


### PR DESCRIPTION
Adds an abstraction over path resolving and importing that supports JavaScript and Typescript for use when resolving paths and importing code.

api looks like:
```js
const path = new PathResolver(opts);
const resolution = await path.resolve("./server");
// or
const server = await path.import("./server");
```

Regardless of whether the file is defined as a TypeScript or JavaScript file, the file will be resolved or imported.

To make this work, Esbuild is used on the fly to transpile TS files to `dist/server/{filename}.js`.

This path resolution module is then used in dev.js and start.js 

Fixes https://github.com/podium-lib/labs/issues/30